### PR TITLE
Feature/support daisy chained devices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build/
 .vscode/
 venv/
 deps/
+avr_toolchain/

--- a/digilent_hs3/hs3program/avr32_prog.py
+++ b/digilent_hs3/hs3program/avr32_prog.py
@@ -132,11 +132,16 @@ def program(
         adapter.Close()
 
     if only_initialize:
+        initialize_adapter(adapter)
         return
 
     if detect:
+        adapter.Close()
+        del adapter
         serials = get_ftdi_device_serials(programmer)
         for serial in serials:
+            adapter = get_adapter(programmer, 12e6, serial)
+            initialize_adapter(adapter)
             adapter.DetectDevices()
             print(f"Found {len(adapter.Devices)} devices on adapter with serial {serial}")
             for i, dev in enumerate(adapter.Devices):

--- a/digilent_hs3/hs3program/avr32_prog.py
+++ b/digilent_hs3/hs3program/avr32_prog.py
@@ -123,9 +123,14 @@ def program(
     dump=None,
     serial=None,
     only_initialize=False,
+    only_close=False,
 ):
     adapter = get_adapter(programmer, 12e6, serial)
     initialize_adapter(adapter)
+
+    if only_close:
+        adapter.Close()
+
     if only_initialize:
         return
 
@@ -208,13 +213,14 @@ def main():
         type=str,
         help="Read the current FLASH contents (if not protected) out into a binary file.",
     )
-    parser.add_argument("--detect", "-d", action="store_true", help="Do detection of devices on JTAG bus")
+    parser.add_argument("--detect", "-d", action="store_true", help="Do detection of devices on JTAG chain")
     parser.add_argument("--flash", "-f", default=None, type=str, help="Path to ELF file to be programmed")
     parser.add_argument("--no-verify", "-V", action="store_true", help="Skip verifying flash")
     parser.add_argument("--fuses", "-GP", default=None, type=str, help="Program fuses")
     parser.add_argument("--verbose", "-v", action="store_true", help="Verbose log output")
     parser.add_argument("--serial", "-s", default=None, type=str, help="Adapter serial number")
     parser.add_argument("--only-initialize", "-I", action="store_true", help="Perform the AVR32 JTAG initialization ritual and exit")
+    parser.add_argument("--only-close", "-C", action="store_true", help="Tickle the RESET pin and exit")
     args = parser.parse_args()
 
     level = logging.DEBUG if args.verbose else logging.INFO

--- a/digilent_hs3/setup.py
+++ b/digilent_hs3/setup.py
@@ -1,8 +1,10 @@
+"""Setup script for hs3program."""
 from setuptools import find_packages
 from setuptools import setup
 
 setup(
     name="hs3program",
+    python_requires=">=3.10",
     version="2.0.0",
     packages=find_packages(),
     install_requires=["pyelftools>=0.29", "pyftdi>=0.54.0"],


### PR DESCRIPTION
This PR adds the `--only-initialize` option to just run the magic AVR32 JTAG initialization ritual (see [the datasheet](https://www.microchip.com/en-us/product/AT32UC3C0512C) section 39.4.7) without closing the ftdi connection.

This allows other, [more capable tools](http://urjtag.org/) to actually use the JTAG chain.

The `--only-close` option will then manually reset the JTAG chain and set it to function as normal.

So the pattern is:

```shell
hs3program -I
# <do your jtag stuff in here>
hs3program -C
```